### PR TITLE
Trying to fix `g0and_bath_function()` and `f0and_bath_function()` in SUPERC mode

### DIFF
--- a/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
+++ b/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
@@ -444,9 +444,9 @@ contains
     select case(type_)
     case default;stop "ed_get_g0and ERROR: type is wrong: either Normal or Anomalous"
     case ('n','N')
-       g0 = g0and_bath_function(x)
+       g0 = g0and_bath_function(x,axis_)
     case('a','A')
-       g0 = f0and_bath_function(x)
+       g0 = f0and_bath_function(x,axis_)
     end select
     call deallocate_dmft_bath()
     !
@@ -479,9 +479,9 @@ contains
     select case(type_)
     case default;stop "ed_get_g0and ERROR: type is wrong: either Normal or Anomalous"
     case ('n','N')
-       g0 = g0and_bath_function(x)
+       g0 = g0and_bath_function(x,axis_)
     case('a','A')
-       g0 = f0and_bath_function(x)
+       g0 = f0and_bath_function(x,axis_)
     end select
     call deallocate_dmft_bath()
     !

--- a/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
+++ b/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
@@ -595,14 +595,8 @@ contains
     N = Nspin*Norb
     L = size(x)
     do concurrent(iorb=1:N)
-       select case(axis)
-       case default
-          zeta(iorb ,1:L)   = x(1:L) + mu
-          zeta(N+iorb,1:L)  = x(1:L) - mu
-       case ('real')
-          zeta(iorb ,1:L)   = x(1:L) + mu
-          zeta(N+iorb,1:L) = -conjg(x(L:1:-1) + mu)
-       end select
+       zeta(iorb ,1:L)   = x(1:L) + mu
+       zeta(N+iorb,1:L)  = x(1:L) - mu
     enddo
   end function zeta_superc
 

--- a/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
+++ b/src/singlesite/ED_BATH/ED_BATH_FUNCTIONS.f90
@@ -590,13 +590,21 @@ contains
     complex(8),dimension(:)                        :: x
     real(8)                                        :: mu
     character(len=*)                               :: axis
+    character(len=1)                               :: axis_
     complex(8),dimension(2*Nspin*Norb,size(x))     :: zeta
     integer                                        :: iorb,N,L
     N = Nspin*Norb
     L = size(x)
+    axis_ = to_lower(axis(1:1))
     do concurrent(iorb=1:N)
-       zeta(iorb ,1:L)   = x(1:L) + mu
-       zeta(N+iorb,1:L)  = x(1:L) - mu
+        select case(axis_)
+        case default
+            zeta(iorb,1:L) = x(1:L) + mu
+            zeta(N+iorb,1:L) = x(1:L) - mu
+        case ('r')
+            zeta(iorb,1:L) = x(1:L) + mu
+            zeta(N+iorb,1:L) = -conjg(x(L:1:-1) + mu)
+        end select
     enddo
   end function zeta_superc
 

--- a/src/singlesite/ED_BATH/g0and_functions/f0and_hyrege.f90
+++ b/src/singlesite/ED_BATH/g0and_functions/f0and_hyrege.f90
@@ -7,7 +7,7 @@ function f0and_bath_array_hyrege(x,axis) result(F0and)
   character(len=1)                                    :: axis_
   complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: F0and
   !
-  complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: Delta,Fdelta
+  complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: Delta,Fdelta12,Fdelta21
   integer                                             :: iorb,jorb,ispin,i,L
   complex(8),dimension(2*Nspin*Norb,size(x))          :: z
   complex(8),dimension(:,:),allocatable               :: fgorb,zeta
@@ -20,7 +20,8 @@ function f0and_bath_array_hyrege(x,axis) result(F0and)
   !
   allocate(fgorb(2*Norb,2*Norb),zeta(2*Norb,2*Norb))
   Delta =  delta_bath_array(x,axis_)
-  Fdelta= fdelta_bath_array(x,axis_)
+  Fdelta12 = fdelta_bath_array(x,axis_)
+  Fdelta21 = fdelta_bath_array(conjg(x),axis_)
   z     = zeta_superc(x,xmu,axis_)
   !
   select case(axis_)
@@ -33,8 +34,8 @@ function f0and_bath_array_hyrege(x,axis) result(F0and)
            do iorb=1,Norb
               do jorb=1,Norb
                  fgorb(iorb,jorb)           = zeta(iorb,jorb)           - impHloc(ispin,ispin,iorb,jorb)  - Delta(ispin,ispin,iorb,jorb,i)
-                 fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
-                 fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
+                 fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta12(ispin,ispin,iorb,jorb,i)
+                 fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - conjg(Fdelta21(ispin,ispin,jorb,iorb,i))
                  fgorb(iorb+Norb,jorb+Norb) = zeta(iorb+Norb,jorb+Norb) + conjg(impHloc(ispin,ispin,iorb,jorb)) + conjg( Delta(ispin,ispin,iorb,jorb,i) )
               enddo
            enddo
@@ -50,8 +51,8 @@ function f0and_bath_array_hyrege(x,axis) result(F0and)
            do iorb=1,Norb
               do jorb=1,Norb
                  fgorb(iorb,jorb)           = zeta(iorb,jorb)           - impHloc(ispin,ispin,iorb,jorb)  - Delta(ispin,ispin,iorb,jorb,i)
-                 fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
-                 fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
+                 fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta12(ispin,ispin,iorb,jorb,i)
+                 fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - conjg(Fdelta21(ispin,ispin,jorb,iorb,i))
                  fgorb(iorb+Norb,jorb+Norb) = zeta(iorb+Norb,jorb+Norb) + conjg(impHloc(ispin,ispin,iorb,jorb))  + conjg( Delta(ispin,ispin,iorb,jorb,L-i+1) )
               enddo
            enddo

--- a/src/singlesite/ED_BATH/g0and_functions/g0and_hyrege.f90
+++ b/src/singlesite/ED_BATH/g0and_functions/g0and_hyrege.f90
@@ -6,7 +6,7 @@ function g0and_bath_array_hyrege(x,axis) result(G0and)
   character(len=*),optional                           :: axis       !string indicating the desired axis, :code:`'m'` for Matsubara (default), :code:`'r'` for Real-axis    
   complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: G0and
   character(len=1)                                    :: axis_
-  complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: Delta,Fdelta
+  complex(8),dimension(Nspin,Nspin,Norb,Norb,size(x)) :: Delta,Fdelta12,Fdelta21
   integer                                             :: iorb,jorb,ispin,jspin,io,jo,Nso,i,L
   real(8),dimension(size(x))                          :: ddet
   complex(8),dimension(size(x))                       :: cdet
@@ -40,7 +40,8 @@ function g0and_bath_array_hyrege(x,axis) result(G0and)
   case ("superc")
      allocate(fgorb(2*Norb,2*Norb),zeta(2*Norb,2*Norb)) !2==Nnambu
      Delta =  delta_bath_array(x,axis_)
-     Fdelta= fdelta_bath_array(x,axis_)
+     Fdelta12 = fdelta_bath_array(x,axis_)
+     Fdelta21 = fdelta_bath_array(conjg(x),axis_)
      z     = zeta_superc(x,xmu,axis_)
      select case(axis_)
      case default;stop "g0and_bath_array_hyrege error: axis_ not supported"
@@ -52,8 +53,8 @@ function g0and_bath_array_hyrege(x,axis) result(G0and)
               do iorb=1,Norb
                  do jorb=1,Norb
                     fgorb(iorb,jorb)           = zeta(iorb,jorb)           - impHloc(ispin,ispin,iorb,jorb)  - Delta(ispin,ispin,iorb,jorb,i)
-                    fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
-                    fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
+                    fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta12(ispin,ispin,iorb,jorb,i)
+                    fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - conjg(Fdelta21(ispin,ispin,jorb,iorb,i))
                     fgorb(iorb+Norb,jorb+Norb) = zeta(iorb+Norb,jorb+Norb) + conjg(impHloc(ispin,ispin,iorb,jorb)) + conjg( Delta(ispin,ispin,iorb,jorb,i) )
                  enddo
               enddo
@@ -69,8 +70,8 @@ function g0and_bath_array_hyrege(x,axis) result(G0and)
               do iorb=1,Norb
                  do jorb=1,Norb
                     fgorb(iorb,jorb)           = zeta(iorb,jorb)           - impHloc(ispin,ispin,iorb,jorb)  - Delta(ispin,ispin,iorb,jorb,i)
-                    fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
-                    fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - Fdelta(ispin,ispin,iorb,jorb,i)
+                    fgorb(iorb,jorb+Norb)      = zeta(iorb,jorb+Norb)                                        - Fdelta12(ispin,ispin,iorb,jorb,i)
+                    fgorb(iorb+Norb,jorb)      = zeta(iorb+Norb,jorb)                                        - conjg(Fdelta21(ispin,ispin,jorb,iorb,i))
                     fgorb(iorb+Norb,jorb+Norb) = zeta(iorb+Norb,jorb+Norb) + conjg(impHloc(ispin,ispin,iorb,jorb))  + conjg( Delta(ispin,ispin,iorb,jorb,L-i+1) )
                  enddo
               enddo


### PR DESCRIPTION
Here is an ongoing effort to fix the procedures calculating normal and anomalous non-interacting Green's functions in the superconducting mode.

* In `zeta_superc()`, the `"real"` case was never selected because the correct axis name would be `"r"`.
* Nonetheless, the expressions in the real branch were equivalent to the default expressions, and the final result of the function was correct.
* I have been trying to apply fixes similar to those implemented by @lcrippa in #28. With theses fixes `g0and_bath_function()` and `f0and_bath_function()` return correct results on the Matsubara axis.
* The real-frequency results are still wrong.

N.B. Results of `delta_bath_function()` and `fdelta_bath_function()` match reference data from a full ED solver on both axes.