### PR TITLE
WIP: Addressing various issues in susceptibility calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ EDIpack authors:
 [Lorenzo Crippa](https://github.com/lcrippa)    
 [Samuele Giuli](https://github.com/SamueleGiuli)    
 [Gabriele Bellomia](https://github.com/beddalumia)    
+[Igor Krivenko](https://github.com/krivenko)  
 Alberto Scazzola   
 Luca de Medici   
 [Giacomo Mazza](https://github.com/GiacMazza)  
@@ -89,7 +90,6 @@ Francesco Petocchi
 [Massimo Capone](https://github.com/massimocapone)
 
 Other important authors contributed to the development of the EDIpack ecosystem:   
-[Igor Krivenko](https://github.com/krivenko)  
 [Alexander Kowalski](https://github.com/alexkowalski)  
 [Markus Wallerberger](https://github.com/mwallerb)   
 [Giorgio Sangiovanni](https://github.com/sangiova) 

--- a/doc/edipack/normal/04_chi_pair.rst
+++ b/doc/edipack/normal/04_chi_pair.rst
@@ -5,19 +5,19 @@ Pair Susceptibility
 
 
 
-In :f:mod:`ed_chi_pair` we evaluate the impurity pair 
+In :f:mod:`ed_chi_pair` we evaluate the impurity pair
 susceptibility, defined as:
 
 .. math::
 
    \chi^{\Delta}_{ab}(\omega) = \frac{1}{\cal
-   Z}\sum_m e^{-\beta E_m} (\langle m | \Delta_a [\omega-H]^{-1} \Delta_b  | m \rangle +
-    \langle m | \Delta_b [\omega+H]^{-1} \Delta_a  | m \rangle )
+   Z}\sum_m e^{-\beta E_m} (\langle m | \Delta^\dagger_a [\omega-H]^{-1} \Delta_b  | m \rangle +
+    \langle m | \Delta_b [\omega+H]^{-1} \Delta^\dagger_a  | m \rangle )
 
 where :math:`\Delta_a = c_{a\uparrow} c_{a\downarrow}` is the fermion
 singlet pair operator of the orbital :math:`a` and :math:`\omega \in {\mathbb C}`. As for the
 Green's functions, the susceptibility is evaluated using the dynamical
-Lanczos method: a) the partial tridiagonalization of the 
+Lanczos method: a) the partial tridiagonalization of the
 sector Hamiltonian :math:`H` with quantum numbers
 :math:`\vec{Q}=[\vec{N}_\uparrow,\vec{N}_\downarrow]` on the Krylov
 basis of :math:`n_a|m\rangle` is obtained; b) the resulting
@@ -27,7 +27,7 @@ any state :math:`| p \rangle` in the spectrum (*without knowing the
 state itself* ) and the excitations energies :math:`\delta E = E_p -
 E_m` or **poles**; c) an controlled approximation to the
 Kallen-Lehmann sum is constructed for  :math:`a,b=1,\dots,N_{\rm
-orb}`. 
+orb}`.
 
 
 

--- a/src/singlesite/ED_NORMAL/ED_CHI_DENS.f90
+++ b/src/singlesite/ED_NORMAL/ED_CHI_DENS.f90
@@ -274,7 +274,7 @@ contains
       write(LOGfile,"(A)")"Get Chi_dens_l"//reg(txtfy(iorb))//reg(txtfy(jorb))
       if(.not.allocated(densChimatrix(iorb,jorb)%state)) return
       !
-      Chi(iorb,jorb,:)= zero
+      Chi(iorb,jorb,:) = zero
       Nstates = size(densChimatrix(iorb,jorb)%state)
       do istate=1,Nstates
          if(.not.allocated(densChimatrix(iorb,jorb)%state(istate)%channel))cycle
@@ -285,27 +285,48 @@ contains
             do iexc=1,Nexcs
                peso = densChimatrix(iorb,jorb)%state(istate)%channel(ichan)%weight(iexc)
                de   = densChimatrix(iorb,jorb)%state(istate)%channel(ichan)%poles(iexc)
-               select case(axis_)
-               case("m","M")
-                  do i=1,size(zeta)
-                    if (abs(zeta(i))<1e-10)then
-                      if(beta*dE > 1d-3)Chi(iorb,jorb,i)=Chi(iorb,jorb,i) + &
-                        peso*2*(1d0-exp(-beta*dE))/dE 
-                     else
-                       Chi(iorb,jorb,i)=Chi(iorb,jorb,i) + &
-                            peso*(1d0-exp(-beta*dE))*2d0*dE/(dimag(zeta(i))**2 + dE**2)
-                    endif
-                  enddo
-               case("r","R")
-                  do i=1,size(zeta)
-                     Chi(iorb,jorb,i)=Chi(iorb,jorb,i) - &
-                          peso*(1d0-exp(-beta*dE))*(1d0/(zeta(i) - dE) - 1d0/(zeta(i) + dE))
-                  enddo
-               case("t","T")
-                  do i=1,size(zeta)
-                     Chi(iorb,jorb,i)=Chi(iorb,jorb,i) + peso*exp(-zeta(i)*dE)
-                  enddo
-               end select
+               ! Zero energy poles are to be taken into account only once
+               if(abs(beta*de) < 1e-8) then
+                 select case(axis_)
+                    case("m","M")
+                       do i=1,size(zeta)
+                          if(abs(zeta(i))<1e-10) then ! \nu=0
+                             Chi(iorb,jorb,i) = Chi(iorb,jorb,i) + peso*beta
+                          endif
+                       enddo
+                    case("r","R")
+                       ! A zero energy pole contributes only to \chi(Re(z) = 0) and
+                       ! its contribution is taken to be the same as for \chi(\nu=0),
+                       ! regardless of the imaginary shift in z
+                       do i=1,size(zeta)
+                          if(abs(dreal(zeta(i)))<1e-10) then
+                             Chi(iorb,jorb,i) = Chi(iorb,jorb,i) + peso*beta
+                          endif
+                       enddo
+                    case("t","T")
+                       Chi(iorb,jorb,:) = Chi(iorb,jorb,:) + peso
+                 end select
+               ! Ignore the negative energy poles and enforce the spectral symmetry by adding
+               ! contributions from de and -de for each positive de
+               elseif(de > 0) then
+                  select case(axis_)
+                     case("m","M")
+                        do i=1,size(zeta)
+                           Chi(iorb,jorb,i) = Chi(iorb,jorb,i) + &
+                              peso*(1d0-exp(-beta*de))*2d0*de/(dimag(zeta(i))**2 + de**2)
+                        enddo
+                     case("r","R")
+                        do i=1,size(zeta)
+                           Chi(iorb,jorb,i) = Chi(iorb,jorb,i) - &
+                              peso*(1d0-exp(-beta*de)) * (1d0/(zeta(i)-de) - 1d0/(zeta(i)+de))
+                        enddo
+                     case("t","T")
+                        do i=1,size(zeta)
+                           Chi(iorb,jorb,i) = Chi(iorb,jorb,i) + &
+                              peso*(exp(-zeta(i)*de) + exp(-(beta-zeta(i))*de))
+                        enddo
+                  end select
+               endif
             enddo
          enddo
       enddo
@@ -314,33 +335,4 @@ contains
     !
   end function get_densChi_normal
 
-
-
-
-
-
 END MODULE ED_CHI_DENS
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/singlesite/ED_NORMAL/ED_CHI_EXCT.f90
+++ b/src/singlesite/ED_NORMAL/ED_CHI_EXCT.f90
@@ -3,7 +3,7 @@ MODULE ED_CHI_EXCT
   !Evaluates the impurity excitonc susceptibility.
   !
   USE SF_CONSTANTS, only:one,xi,zero,pi
-  USE SF_TIMER  
+  USE SF_TIMER
   USE SF_IOTOOLS, only: str,free_unit,reg,free_units,txtfy
   USE SF_LINALG,  only: inv,eigh,eye
   USE SF_SP_LINALG, only: sp_lanc_tridiag
@@ -40,15 +40,15 @@ contains
 
   !+------------------------------------------------------------------+
   !                            EXCITON
-  !PURPOSE  : Evaluate the Exciton susceptibility \Chi_exct for a 
+  !PURPOSE  : Evaluate the Exciton susceptibility \Chi_exct for a
   ! \chi_ab = <O*_a(\tau)O_b(0)>
   ! a/=b
-  ! Singlet: \sum_\sigma <C^+_{a\sigma}C_{b\sigma} 
+  ! Singlet: \sum_\sigma <C^+_{a\sigma}C_{b\sigma}
   ! Triplet: \sum_{\sigma\rho} C^+_{a\sigma} \tau_{\sigma\rho} C_{b\rho}
   !+------------------------------------------------------------------+
   subroutine build_exctChi_normal()
-    ! Evaluates the impurity exciton-exciton susceptibility :math:`\chi^{X}_{ab}=\langle T_\tau X^\dagger_{ab}(\tau) X_{ab}\rangle` in the Matsubara :math:`i\omega_n` and Real :math:`\omega` frequency axis, the imaginary time :math:`\tau` as well as the singlet and triplet components of the operator. 
-    ! As for the Green's function, the off-diagonal component of the the susceptibility is determined using an algebraic manipulation to ensure use of Hermitian operator in the dynamical Lanczos. 
+    ! Evaluates the impurity exciton-exciton susceptibility :math:`\chi^{X}_{ab}=\langle T_\tau X^\dagger_{ab}(\tau) X_{ab}\rangle` in the Matsubara :math:`i\omega_n` and Real :math:`\omega` frequency axis, the imaginary time :math:`\tau` as well as the singlet and triplet components of the operator.
+    ! As for the Green's function, the off-diagonal component of the the susceptibility is determined using an algebraic manipulation to ensure use of Hermitian operator in the dynamical Lanczos.
     !
 #if __INTEL_COMPILER
     use ED_INPUT_VARS, only: Nspin,Norb
@@ -141,7 +141,7 @@ contains
   ! O_ab = \sum_sp C^+_{as}.tau^o_{sp}.C_{bp} with o=X,Y
   ! O_ab|0> X:=   [C^+_{a,up}C_{b,dw} + C^+_{a,dw}C_{b,up}]|0>
   !         Y:= -i[C^+_{a,up}C_{b,dw} - C^+_{a,dw}C_{b,up}]|0>
-  !         X:=   [P_{up,dw} +  P_{dw,up}]|0> = |v> + |w> 
+  !         X:=   [P_{up,dw} +  P_{dw,up}]|0> = |v> + |w>
   !         X:= -i[P_{up,dw} -  P_{dw,up}]|0> = |v> + |w>
   ! If |0>\in\SS(N_up,N_dw) => |v>\in\SS(N_up+1,N_dw-1), |w>\in\SS(N_up-1,N_dw+1)
   ! so that the sum |v> + |w> can not be accumulated onto a single vector |vvinit>
@@ -151,7 +151,7 @@ contains
   ! the mixed terms: <v|[z-H]^{-1}|w> and <w|[z-H]^{-1}|v> are indeed null.
   ! Proof:
   ! |v> and |w> belong to different sectors. H has a sector-block structure and so
-  ! does its inverse H^{-1} made of the inverse of each block. 
+  ! does its inverse H^{-1} made of the inverse of each block.
   ! The expected values <v|H^{-1}|w> are taken across different sectors, but unless
   ! spin-conservation is broken these sectors are not connected and, as such, these
   ! numbers have to be zero.
@@ -174,7 +174,7 @@ contains
        e_state    =  es_return_energy(state_list,istate)
        v_state    =  es_return_dvec(state_list,istate)
        !
-       !X - Component == Y -Component 
+       !X - Component == Y -Component
        !X_{ab}= C^+_{a,up}C_{b,dw} + C^+_{a,dw}C_{b,up}
        !
        !C^+_{a,dw}C_{b,up}: First Lesser component
@@ -317,11 +317,11 @@ contains
     use ED_INPUT_VARS, only: Nspin,Norb
 #endif
     integer                                    :: iorb,jorb,ichan,indx,isign,istate
-    real(8)                                    :: pesoF,pesoAB,pesoBZ,peso,vnorm2  
+    real(8)                                    :: pesoF,pesoAB,pesoBZ,peso,vnorm2
     real(8)                                    :: Ei,Ej,Egs,de
     integer                                    :: nlanc
     real(8),dimension(:)                       :: alanc
-    real(8),dimension(size(alanc))             :: blanc 
+    real(8),dimension(size(alanc))             :: blanc
     real(8),dimension(size(alanc),size(alanc)) :: Z
     real(8),dimension(size(alanc))             :: diag,subdiag
     integer                                    :: i,j,ierr
@@ -341,7 +341,7 @@ contains
     !
     Nlanc = size(alanc)
     !
-    pesoF  = vnorm2/zeta_function 
+    pesoF  = vnorm2/zeta_function
     if((finiteT).and.(beta*(Ei-Egs) < 200))then
        pesoBZ = exp(-beta*(Ei-Egs))
     elseif(.not.finiteT)then
@@ -381,7 +381,7 @@ contains
 
 
 
-  
+
   !################################################################
   !################################################################
   !################################################################
@@ -480,6 +480,9 @@ contains
                        enddo
                     case("t","T")
                        Chi(indx,iorb,jorb,:) = Chi(indx,iorb,jorb,:) + 0.5*peso
+                       if(iorb /= jorb) then
+                          Chi(indx,jorb,iorb,:) = Chi(indx,jorb,iorb,:) + 0.5*peso
+                       endif
                  end select
                ! Nonzero energy poles
                elseif(merge(de, -de, mod(ichan,2)==1)>0) then


### PR DESCRIPTION
* Properly handle the zero energy poles on all three axes (spin and density channels).
* Ignore the negative energy poles and enforce the spectral symmetry by adding contributions from de and -de for each positive de (spin and density channels).
* The algorithm has been changed to build the Källén–Lehmann representation of the excitonic susceptibilities out of the non-negative energy contributions (dE >= 0) to the lesser and greater correlators $\langle X^\dagger_{ab}(\tau) X_{ab}(0)\rangle$ and $\langle X_{ab}(\tau) X^\dagger_{ab}(0)\rangle$. This new approach gives accurate results and does not make the erroneous assumption of the excitonic susceptibility having a symmetric spectrum. Credits to @lcrippa for proposing the idea.
* All orbital matrix elements of the excitonic susceptibility are now computed. The elements with jorb\<iorb are derived from jorb\>iorb using the time reversal symmetry.
* Fixed an off-by-one bug in a debugging output statement.